### PR TITLE
Don't fail with an error if there are no mappings

### DIFF
--- a/lua/other-nvim/init.lua
+++ b/lua/other-nvim/init.lua
@@ -37,7 +37,7 @@ local defaults = {
 local findOther = function(filename, context)
 	local matches = {}
 	-- iterate over all the mapping to check if the filename matches against any "pattern")
-	for _, mapping in pairs(options.mappings) do
+	for _, mapping in pairs(options.mappings or {}) do
 		local match
 
 		if mapping.context == context then


### PR DESCRIPTION
This PR fixes the following error:

<img width="1168" alt="CleanShot 2022-06-21 at 19 29 15@2x" src="https://user-images.githubusercontent.com/87562/174861507-cb1ab28f-a6fa-42b5-9159-0ecda0c55e0b.png">

It occurs when calling commands without having configured the plugin.